### PR TITLE
Send more debug information in hello command

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -110,7 +110,7 @@ function instrumental_send(payload) {
       "hello version node/statsd-instrumental-backend/" + cleanString(package.version) +
         " hostname " + cleanString(hostname) +
         " pid " + cleanString(process.pid) +
-        " node " + cleanString(process.versions.node) +
+        " runtime " + cleanString("node/" + process.versions.node) +
         " platform " + cleanString(process.platform + "-" + process.arch) + "\n" +
       "authenticate " + key + "\n"
     );

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -138,18 +138,16 @@ function instrumental_send(payload) {
   });
 
   // What do we do when instrumental talks to us
-  //
-  // You know, we're early in the development cycle. We will (at most) expect
-  // to receive "ok\nok\n" back from the server (ACK our header). Such a small
-  // amount of data shouldn't be split into multiple packets... though I guess
-  // we will find out.
+  var totalBuffer = "";
   client.on("data", function(buffer) {
+    totalBuffer = totalBuffer + buffer;
+
     if(debug) {
       util.puts("Received:", buffer);
     }
 
     // Authorization success
-    if(buffer == "ok\nok\n") {
+    if(totalBuffer == "ok\nok\n") {
       error = false;
 
       if(debug) {
@@ -163,7 +161,7 @@ function instrumental_send(payload) {
       instrumentalStats.last_flush = Math.round(new Date().getTime() / 1000);
 
     // Authorization failure
-    } else if(buffer == "ok\nfail\n") {
+    } else if(totalBuffer.length >= "ok\nok\n".length) {
       // TODO: Actually do something with this
       error = true;
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -21,11 +21,15 @@
 
 var net  = require("net"),
     util = require("util"),
+    os = require("os"),
+    dns = require("dns"),
+    package = require('../package.json'),
     buffering_aggregation = require("./instrumental/buffering_aggregation"),
     p = require("./instrumental/protocol");
 
 var debug;
 var error = false;
+var hostname = "unknown";
 
 var key, host, port, timeout, flushInterval;
 
@@ -97,9 +101,17 @@ function instrumental_send(payload) {
     // Connetion Established. Lets go shopping
     state = "connected";
 
+    var cleanString = function(value) {
+      return String(value).replace(/\s+/, "_");
+    }
+
     // Write the authentication header
     client.write(
-      "hello version 1.0\n" +
+      "hello version node/statsd-instrumental-backend/" + cleanString(package.version) +
+        " hostname " + cleanString(hostname) +
+        " pid " + cleanString(process.pid) +
+        " node " + cleanString(process.versions.node) +
+        " platform " + cleanString(process.platform + "-" + process.arch) + "\n" +
       "authenticate " + key + "\n"
     );
   });
@@ -204,6 +216,16 @@ exports.init = function instrumental_init(startup_time, config, events) {
 
   events.on("flush", instrumental_flush);
   events.on("status", instrumental_status);
+
+  dns.resolve(os.hostname(), function(err, ips) {
+    if (!err) {
+      dns.reverse(ips[0], function (err, domains) {
+        if (!err && String(domains[0]).length > 0) {
+          hostname = domains[0];
+        }
+      });
+    }
+  });
 
   return true;
 };

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -29,7 +29,7 @@ var net  = require("net"),
 
 var debug;
 var error = false;
-var hostname = "unknown";
+var hostname = os.hostname();
 
 var key, host, port, timeout, flushInterval;
 
@@ -216,8 +216,7 @@ exports.init = function instrumental_init(startup_time, config, events) {
 
   events.on("flush", instrumental_flush);
   events.on("status", instrumental_status);
-
-  dns.resolve(os.hostname(), function(err, ips) {
+  dns.resolve(hostname, function(err, ips) {
     if (!err) {
       dns.reverse(ips[0], function (err, domains) {
         if (!err && String(domains[0]).length > 0) {


### PR DESCRIPTION
Allows for easier server-side debugging by sending the equivalient of an HTTP
Agent string.

Other notable change is handling a response that comes in over multiple packets. This basically had a FIXME comment.