### PR TITLE
Add an exampleConfig.js and documentation

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -7,7 +7,7 @@ See the offical Statsd exampleConfig.js for more StatsD options.
 , backends: ["statsd-instrumental-backend" ]
 , debug: false
 , instrumental: {
-    key: "INSTRUMENTAL_API_KEY", // REQUIRED
+    key: "PROJECT_API_TOKEN", // REQUIRED
     secure: true, // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
     verify_cert: true, // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000, // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s


### PR DESCRIPTION
People that are new to StatsD (or alternative backends) often request help getting the configuration right. Also handy for setting up quick test environments.