### PR TITLE
Make example config javascripty and consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ StatsD config file.
   instrumental: {
     key: "[application api key]", // REQUIRED
     secure: true,                 // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
-    verify_cert: true,            // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
+    verifyCert: true,            // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000                // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
   }
 }

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -9,7 +9,7 @@ exports.config = {
 , instrumental: {
     key: "INSTRUMENTAL_API_KEY", // REQUIRED
     secure: true, // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
-    verify_cert: true, // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
+    verifyCert: true, // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000, // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
     recordCounterRates: true, // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
   }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -234,10 +234,16 @@ exports.init = function instrumental_init(startup_time, config, events) {
     } else {
       secure = config.instrumental.secure;
     }
-    if(typeof(config.instrumental.verify_cert) == 'undefined'){
-      verifyCert = true;
+
+    // necessary while we transition config from verify_cert to verifyCert.
+    if(typeof(config.instrumental.verifyCert) == 'undefined'){
+      if(typeof(config.instrumental.verify_cert) == 'undefined'){
+        verifyCert = true;
+      } else {
+        verifyCert = config.instrumental.verify_cert;
+      }
     } else {
-      verifyCert = config.instrumental.verify_cert;
+      verifyCert = config.instrumental.verifyCert;
     }
     if(secure && verifyCert){
       var certDir = path.join(__dirname, caChainPath);


### PR DESCRIPTION
When verify_cert was added, it used ruby conventions, which was fine, because it was the only multiword setting.  Now, it isn't, and the lack of convention looks weird.  This branch makes camelCase preferred, but allows snake_case to be used for verifyCert to ease the transition.